### PR TITLE
fix: update config for bottom >= 0.10.2

### DIFF
--- a/bottom.tera
+++ b/bottom.tera
@@ -9,14 +9,13 @@ whiskers:
 {%- set palette = flavor.colors -%}
 {%- set rainbow = [palette.red, palette.peach, palette.yellow, palette.green, palette.sapphire, palette.mauve] -%}
 
-[styles.tables]
-headers = {color = "#{{ palette.rosewater.hex }}"}
 [styles.cpu]
 all_entry_color = "#{{ palette.rosewater.hex }}"
 avg_entry_color = "#{{ palette.maroon.hex }}"
 cpu_core_colors = [{%- for color in rainbow -%}"#{{ color.hex }}"{%- if not loop.last -%},{%- endif -%}{%- endfor -%}]
 [styles.memory]
 ram_color = "#{{ palette.green.hex }}"
+cache_color = "#{{ palette.peach.hex }}"
 swap_color = "#{{ palette.peach.hex }}"
 {%- set sliced_rainbow = rainbow | slice(start=0, end=4) %}
 gpu_colors = [{%- for color in rainbow | slice(start=4) | concat(with=sliced_rainbow) -%}"#{{ color.hex }}"{%- if not loop.last -%},{%- endif -%}{%- endfor -%}]
@@ -24,15 +23,21 @@ arc_color = "#{{ palette.sky.hex }}"
 [styles.network]
 rx_color = "#{{ palette.green.hex }}"
 tx_color = "#{{ palette.red.hex }}"
-[styles.widgets]
-widget_title = {color = "#{{ palette.flamingo.hex }}"}
-border_color = "#{{ palette.surface2.hex }}"
-selected_border_color = "#{{ palette.pink.hex }}"
-text = {color = "#{{ palette.text.hex }}"}
-selected_text = {color = "#{{ palette.crust.hex }}", bg_color = "#{{ palette.mauve.hex }}"}
-[styles.graphs]
-graph_color = "#{{ palette.subtext0.hex }}"
+rx_total_color = "#{{ palette.sky.hex }}"
+tx_total_color = "#{{ palette.green.hex }}"
 [styles.battery]
 high_battery_color = "#{{ palette.green.hex }}"
 medium_battery_color = "#{{ palette.yellow.hex }}"
 low_battery_color = "#{{ palette.red.hex }}"
+[styles.tables]
+headers = {color = "#{{ palette.rosewater.hex }}"}
+[styles.graphs]
+graph_color = "#{{ palette.subtext0.hex }}"
+legend_text = {color = "#{{ palette.subtext0.hex }}"}
+[styles.widgets]
+border_color = "#{{ palette.surface2.hex }}"
+selected_border_color = "#{{ palette.pink.hex }}"
+widget_title = {color = "#{{ palette.flamingo.hex }}"}
+text = {color = "#{{ palette.text.hex }}"}
+selected_text = {color = "#{{ palette.crust.hex }}", bg_color = "#{{ palette.mauve.hex }}"}
+disabled_text = {color = "#{{ palette.base.hex }}"}

--- a/bottom.tera
+++ b/bottom.tera
@@ -15,7 +15,7 @@ avg_entry_color = "#{{ palette.maroon.hex }}"
 cpu_core_colors = [{%- for color in rainbow -%}"#{{ color.hex }}"{%- if not loop.last -%},{%- endif -%}{%- endfor -%}]
 [styles.memory]
 ram_color = "#{{ palette.green.hex }}"
-cache_color = "#{{ palette.peach.hex }}"
+cache_color = "#{{ palette.red.hex }}"
 swap_color = "#{{ palette.peach.hex }}"
 {%- set sliced_rainbow = rainbow | slice(start=0, end=4) %}
 gpu_colors = [{%- for color in rainbow | slice(start=4) | concat(with=sliced_rainbow) -%}"#{{ color.hex }}"{%- if not loop.last -%},{%- endif -%}{%- endfor -%}]

--- a/themes/frappe.toml
+++ b/themes/frappe.toml
@@ -1,26 +1,31 @@
-[styles.tables]
-headers = {color = "#f2d5cf"}
 [styles.cpu]
 all_entry_color = "#f2d5cf"
 avg_entry_color = "#ea999c"
 cpu_core_colors = ["#e78284","#ef9f76","#e5c890","#a6d189","#85c1dc","#ca9ee6"]
 [styles.memory]
 ram_color = "#a6d189"
+cache_color = "#ef9f76"
 swap_color = "#ef9f76"
 gpu_colors = ["#85c1dc","#ca9ee6","#e78284","#ef9f76","#e5c890","#a6d189"]
 arc_color = "#99d1db"
 [styles.network]
 rx_color = "#a6d189"
 tx_color = "#e78284"
-[styles.widgets]
-widget_title = {color = "#eebebe"}
-border_color = "#626880"
-selected_border_color = "#f4b8e4"
-text = {color = "#c6d0f5"}
-selected_text = {color = "#232634", bg_color = "#ca9ee6"}
-[styles.graphs]
-graph_color = "#a5adce"
+rx_total_color = "#99d1db"
+tx_total_color = "#a6d189"
 [styles.battery]
 high_battery_color = "#a6d189"
 medium_battery_color = "#e5c890"
 low_battery_color = "#e78284"
+[styles.tables]
+headers = {color = "#f2d5cf"}
+[styles.graphs]
+graph_color = "#a5adce"
+legend_text = {color = "#a5adce"}
+[styles.widgets]
+border_color = "#626880"
+selected_border_color = "#f4b8e4"
+widget_title = {color = "#eebebe"}
+text = {color = "#c6d0f5"}
+selected_text = {color = "#232634", bg_color = "#ca9ee6"}
+disabled_text = {color = "#303446"}

--- a/themes/frappe.toml
+++ b/themes/frappe.toml
@@ -4,7 +4,7 @@ avg_entry_color = "#ea999c"
 cpu_core_colors = ["#e78284","#ef9f76","#e5c890","#a6d189","#85c1dc","#ca9ee6"]
 [styles.memory]
 ram_color = "#a6d189"
-cache_color = "#ef9f76"
+cache_color = "#e78284"
 swap_color = "#ef9f76"
 gpu_colors = ["#85c1dc","#ca9ee6","#e78284","#ef9f76","#e5c890","#a6d189"]
 arc_color = "#99d1db"

--- a/themes/latte.toml
+++ b/themes/latte.toml
@@ -4,7 +4,7 @@ avg_entry_color = "#e64553"
 cpu_core_colors = ["#d20f39","#fe640b","#df8e1d","#40a02b","#209fb5","#8839ef"]
 [styles.memory]
 ram_color = "#40a02b"
-cache_color = "#fe640b"
+cache_color = "#d20f39"
 swap_color = "#fe640b"
 gpu_colors = ["#209fb5","#8839ef","#d20f39","#fe640b","#df8e1d","#40a02b"]
 arc_color = "#04a5e5"

--- a/themes/latte.toml
+++ b/themes/latte.toml
@@ -1,26 +1,31 @@
-[styles.tables]
-headers = {color = "#dc8a78"}
 [styles.cpu]
 all_entry_color = "#dc8a78"
 avg_entry_color = "#e64553"
 cpu_core_colors = ["#d20f39","#fe640b","#df8e1d","#40a02b","#209fb5","#8839ef"]
 [styles.memory]
 ram_color = "#40a02b"
+cache_color = "#fe640b"
 swap_color = "#fe640b"
 gpu_colors = ["#209fb5","#8839ef","#d20f39","#fe640b","#df8e1d","#40a02b"]
 arc_color = "#04a5e5"
 [styles.network]
 rx_color = "#40a02b"
 tx_color = "#d20f39"
-[styles.widgets]
-widget_title = {color = "#dd7878"}
-border_color = "#acb0be"
-selected_border_color = "#ea76cb"
-text = {color = "#4c4f69"}
-selected_text = {color = "#dce0e8", bg_color = "#8839ef"}
-[styles.graphs]
-graph_color = "#6c6f85"
+rx_total_color = "#04a5e5"
+tx_total_color = "#40a02b"
 [styles.battery]
 high_battery_color = "#40a02b"
 medium_battery_color = "#df8e1d"
 low_battery_color = "#d20f39"
+[styles.tables]
+headers = {color = "#dc8a78"}
+[styles.graphs]
+graph_color = "#6c6f85"
+legend_text = {color = "#6c6f85"}
+[styles.widgets]
+border_color = "#acb0be"
+selected_border_color = "#ea76cb"
+widget_title = {color = "#dd7878"}
+text = {color = "#4c4f69"}
+selected_text = {color = "#dce0e8", bg_color = "#8839ef"}
+disabled_text = {color = "#eff1f5"}

--- a/themes/macchiato.toml
+++ b/themes/macchiato.toml
@@ -4,7 +4,7 @@ avg_entry_color = "#ee99a0"
 cpu_core_colors = ["#ed8796","#f5a97f","#eed49f","#a6da95","#7dc4e4","#c6a0f6"]
 [styles.memory]
 ram_color = "#a6da95"
-cache_color = "#f5a97f"
+cache_color = "#ed8796"
 swap_color = "#f5a97f"
 gpu_colors = ["#7dc4e4","#c6a0f6","#ed8796","#f5a97f","#eed49f","#a6da95"]
 arc_color = "#91d7e3"

--- a/themes/macchiato.toml
+++ b/themes/macchiato.toml
@@ -1,26 +1,31 @@
-[styles.tables]
-headers = {color = "#f4dbd6"}
 [styles.cpu]
 all_entry_color = "#f4dbd6"
 avg_entry_color = "#ee99a0"
 cpu_core_colors = ["#ed8796","#f5a97f","#eed49f","#a6da95","#7dc4e4","#c6a0f6"]
 [styles.memory]
 ram_color = "#a6da95"
+cache_color = "#f5a97f"
 swap_color = "#f5a97f"
 gpu_colors = ["#7dc4e4","#c6a0f6","#ed8796","#f5a97f","#eed49f","#a6da95"]
 arc_color = "#91d7e3"
 [styles.network]
 rx_color = "#a6da95"
 tx_color = "#ed8796"
-[styles.widgets]
-widget_title = {color = "#f0c6c6"}
-border_color = "#5b6078"
-selected_border_color = "#f5bde6"
-text = {color = "#cad3f5"}
-selected_text = {color = "#181926", bg_color = "#c6a0f6"}
-[styles.graphs]
-graph_color = "#a5adcb"
+rx_total_color = "#91d7e3"
+tx_total_color = "#a6da95"
 [styles.battery]
 high_battery_color = "#a6da95"
 medium_battery_color = "#eed49f"
 low_battery_color = "#ed8796"
+[styles.tables]
+headers = {color = "#f4dbd6"}
+[styles.graphs]
+graph_color = "#a5adcb"
+legend_text = {color = "#a5adcb"}
+[styles.widgets]
+border_color = "#5b6078"
+selected_border_color = "#f5bde6"
+widget_title = {color = "#f0c6c6"}
+text = {color = "#cad3f5"}
+selected_text = {color = "#181926", bg_color = "#c6a0f6"}
+disabled_text = {color = "#24273a"}

--- a/themes/mocha.toml
+++ b/themes/mocha.toml
@@ -1,26 +1,31 @@
-[styles.tables]
-headers = {color = "#f5e0dc"}
 [styles.cpu]
 all_entry_color = "#f5e0dc"
 avg_entry_color = "#eba0ac"
 cpu_core_colors = ["#f38ba8","#fab387","#f9e2af","#a6e3a1","#74c7ec","#cba6f7"]
 [styles.memory]
 ram_color = "#a6e3a1"
+cache_color = "#fab387"
 swap_color = "#fab387"
 gpu_colors = ["#74c7ec","#cba6f7","#f38ba8","#fab387","#f9e2af","#a6e3a1"]
 arc_color = "#89dceb"
 [styles.network]
 rx_color = "#a6e3a1"
 tx_color = "#f38ba8"
-[styles.widgets]
-widget_title = {color = "#f2cdcd"}
-border_color = "#585b70"
-selected_border_color = "#f5c2e7"
-text = {color = "#cdd6f4"}
-selected_text = {color = "#11111b", bg_color = "#cba6f7"}
-[styles.graphs]
-graph_color = "#a6adc8"
+rx_total_color = "#89dceb"
+tx_total_color = "#a6e3a1"
 [styles.battery]
 high_battery_color = "#a6e3a1"
 medium_battery_color = "#f9e2af"
 low_battery_color = "#f38ba8"
+[styles.tables]
+headers = {color = "#f5e0dc"}
+[styles.graphs]
+graph_color = "#a6adc8"
+legend_text = {color = "#a6adc8"}
+[styles.widgets]
+border_color = "#585b70"
+selected_border_color = "#f5c2e7"
+widget_title = {color = "#f2cdcd"}
+text = {color = "#cdd6f4"}
+selected_text = {color = "#11111b", bg_color = "#cba6f7"}
+disabled_text = {color = "#1e1e2e"}

--- a/themes/mocha.toml
+++ b/themes/mocha.toml
@@ -4,7 +4,7 @@ avg_entry_color = "#eba0ac"
 cpu_core_colors = ["#f38ba8","#fab387","#f9e2af","#a6e3a1","#74c7ec","#cba6f7"]
 [styles.memory]
 ram_color = "#a6e3a1"
-cache_color = "#fab387"
+cache_color = "#f38ba8"
 swap_color = "#fab387"
 gpu_colors = ["#74c7ec","#cba6f7","#f38ba8","#fab387","#f9e2af","#a6e3a1"]
 arc_color = "#89dceb"


### PR DESCRIPTION
Updated tera files for bottom >= 0.10.2 config format. Follows consistency with [default_config.toml](https://github.com/ClementTsang/bottom/blob/main/sample_configs/default_config.toml).

Notable changes:
- Added `cache_color` in styles.memory
- Added `rx_total_color` & `tx_total_color` in styles.network
- Added `legend_text` in styles.graphs
- Added `disabled_text` in styles.widgets